### PR TITLE
INTERNAL-411-59 - Fix show product button styling issue

### DIFF
--- a/app/design/frontend/Satoshi/Hyva/Magento_Catalog/templates/product/view/product-actions.phtml
+++ b/app/design/frontend/Satoshi/Hyva/Magento_Catalog/templates/product/view/product-actions.phtml
@@ -316,7 +316,7 @@ $cartMessage = $block->getCartMessage();
         style="display: none"
       <?php endif; ?>
       x-show="<?= (int) ($productType !== 'downloadable') ?> && (!isVariantInCart || <?= (int) $isPopup ?>)"
-      class="animate-on-transition button button--outline-primary w-full md:hidden"
+      class="animate-on-transition button button--outline-primary flex-grow md:hidden"
       :class="
       {
         'max-md:hidden': !isVariantInCart || !<?= (int) $isPopup ?>


### PR DESCRIPTION
If a product is already in the cart, then the "Show product" button on bigger mobile devices (that have enough space to fit all elements in a row), takes the full width and ruins the UI. It is because the classes of the "Show product" button are not consistent with the classes of the "Add to cart" button. [Here](https://monosnap.com/direct/Sxo5Bv76LqBQxr9LYKSyquRGn9rH4t) you can see the issue.