### PR TITLE
INTERNAL-411-55 - Fix disabled attribute bug

### DIFF
--- a/app/design/frontend/Satoshi/Hyva/Magento_Swatches/templates/product/swatch-item.phtml
+++ b/app/design/frontend/Satoshi/Hyva/Magento_Swatches/templates/product/swatch-item.phtml
@@ -27,7 +27,7 @@ if (!$productId || !$attributeId) {
 <template x-if="optionIsEnabled(<?= (int) $attributeId ?>, item.id)">
   <label
     :for="`attribute-option-<?= (int) $productId ?>-${item.id}`"
-    @click="changeOption(<?= (int) $attributeId ?>, item.id)"
+    @click="optionIsActive(<?= (int) $attributeId ?>, item.id) && changeOption(<?= (int) $attributeId ?>, item.id)"
     class="button button--size-sm select-none transition-all ease-in-out relative bg-bg-500"
     :class="
       {
@@ -61,6 +61,7 @@ if (!$productId || !$attributeId) {
       :aria-label="getSwatchText(<?= (int)$attributeId ?>, item.id)"
       aria-describedby="attribute-label-<?= $escaper->escapeHtmlAttr($productId . '-' . $attributeId) ?>"
       form="<?= $escaper->escapeHtmlAttr($formId) ?>"
+      :disabled="!optionIsActive(<?= (int) $attributeId ?>, item.id)"
     >
     <template x-if="isTextSwatch(<?= (int) $attributeId ?>, item.id)">
       <span class="line-clamp-2 text-wrap text-sm md:text-md" x-html="getSwatchText(<?= (int) $attributeId ?>, item.id)"></span>


### PR DESCRIPTION
Resolved issue 55 from the QA issues sheet: If a variant of a configurable product becomes out of stock and then if you hover over the out of stock option, the cursor shows a disabled icon, but you still can select it if you click on it.

Screenshot of the issue: https://monosnap.com/direct/Q1rtSJEVDwXFrUEJ6wSY6KcbTkAtrp