### PR TITLE
INTERNAL-411-3; Fix img animation in PLP

### DIFF
--- a/app/design/frontend/Satoshi/Hyva/Magento_Catalog/templates/product/list/item.phtml
+++ b/app/design/frontend/Satoshi/Hyva/Magento_Catalog/templates/product/list/item.phtml
@@ -114,7 +114,8 @@ if ($product) {
 
                 <?php if ($product): ?>
                     <div
-                        class="bg-[--fade-in-bg] aspect-product size-full flex min-h-0 items-center justify-center transition-transform md:group-hover:scale-105 p-[2%]">
+                        class="bg-[--fade-in-bg] aspect-product size-full flex min-h-0 items-center justify-center transition-transform md:group-hover:scale-105 <?= $isContain ? 'p-[2%]' : '' ?>"
+                    >
                         <img
                             class="mix-blend-darken object-center max-h-full md:group-hover:scale-105 <?= $isContain ? 'object-contain rounded-md p-[2%]' : 'object-cover h-full w-full' ?>"
                             src="<?= $escaper->escapeUrl($imageUrl) ?>"


### PR DESCRIPTION
Hover on PDL's img was not animating, issue fixed by adding the missing classes from shopify
![image](https://github.com/user-attachments/assets/ccde7937-a9a8-4df4-9d8a-7c0f9ffe67c9)
