### PR TITLE
INTERNAL-411-63 - Fix cart totals issue on mobile

### DIFF
--- a/app/design/frontend/Satoshi/Hyva/Magento_Checkout/templates/cart-main.phtml
+++ b/app/design/frontend/Satoshi/Hyva/Magento_Checkout/templates/cart-main.phtml
@@ -7,7 +7,7 @@ use Satoshi\Theme\Block\Template;
 $title = $block->getLayout()->createBlock('Magento\Theme\Block\Html\Title')->getPageHeading();
 ?>
 
-<div class="md:content-wrapper mt-[72px] md:mx-auto md:pb-10  max-md:h-[calc(100vh-106px)] max-md:overflow-y-scroll">
+<div class="cart-main md:content-wrapper mt-[72px] md:mx-auto md:pb-10 max-md:h-[calc(100vh-106px)] max-md:overflow-y-scroll">
   <?=
     $template
       ->setData([

--- a/app/design/frontend/Satoshi/Hyva/Magento_Theme/templates/html/header/cart/minicart-overlay.phtml
+++ b/app/design/frontend/Satoshi/Hyva/Magento_Theme/templates/html/header/cart/minicart-overlay.phtml
@@ -131,18 +131,22 @@ $title = $block->getData('title');
           </div>
         </template>
         <?php else : ?>
-        <div
-          <?php if (!$cartItemsCount) : ?>
-          style="display: none"
-          <?php endif; ?>
-          class="relative overflow-x-clip px-4 md:rounded-b-md max-md:px-3 max-md:fixed bottom-0 left-0 right-0 md:w-[--minicart-width] md:h-full md:border md:rounded-sm"
-          x-show="!isCartEmpty"
-        >
-          <?=
-            $template
-              ->setData(['isCartPage' => $isCartPage])
-              ->render('Magento_Theme::html/header/cart/minicart-totals.phtml')
-          ?>
+        <div id="cart-totals" class="contents">
+          <template x-portal="$store.main.isMobile ? document.querySelector('body') : document.getElementById('cart-totals')">
+            <div
+              <?php if (!$cartItemsCount) : ?>
+              style="display: none"
+              <?php endif; ?>
+              class="relative overflow-x-clip px-4 md:rounded-b-md max-md:px-3 max-md:fixed bottom-0 left-0 right-0 md:w-[--minicart-width] md:h-full md:border md:rounded-sm"
+              x-show="!isCartEmpty"
+            >
+              <?=
+                $template
+                  ->setData(['isCartPage' => $isCartPage])
+                  ->render('Magento_Theme::html/header/cart/minicart-totals.phtml')
+              ?>
+            </div>
+          </template>
         </div>
         <?php endif; ?>
       </div>

--- a/app/design/frontend/Satoshi/Hyva/web/satoshi/theme/app.scss
+++ b/app/design/frontend/Satoshi/Hyva/web/satoshi/theme/app.scss
@@ -169,6 +169,10 @@ h3 {
   @apply sr-only;
 }
 
+.cart-main + .product-slider {
+  @apply max-md:mb-28;
+}
+
 @layer components {
   @import "components/content-wrapper";
   @import "components/checkbox";


### PR DESCRIPTION
Fixed issue 63 from the QA issues sheet: On the cart page, on mobile, scroll down. the slider is on top of the "Secure checkout" button. we can't even click the button. the issue happens because the cart totals is not attached to the bottom of the viewport. instead, it is at the end of the content.

Screenshot of the issue: https://monosnap.com/direct/k492gIJQP79WLttlJhN1bjjskBkX17