### PR TITLE
INTERNAL-411-52 - Fix product actions UI issue on mobile

### DIFF
--- a/app/design/frontend/Satoshi/Hyva/Magento_Catalog/templates/product/view/product-actions.phtml
+++ b/app/design/frontend/Satoshi/Hyva/Magento_Catalog/templates/product/view/product-actions.phtml
@@ -73,6 +73,7 @@ $cartMessage = $block->getCartMessage();
           ['configurable', 'downloadable', 'grouped', 'bundle']) && !$isPopup) ? 'max-md:hidden' : '' ?>
         <?= $isSmall ? 'button--size-sm' : '' ?>
         animate-on-transition button button--filled-primary flex-grow
+        <?= $isPopup ? 'max-sm:px-3' : '' ?>
       "
       :class="
         {
@@ -287,7 +288,12 @@ $cartMessage = $block->getCartMessage();
         style="display: none"
       <?php endif; ?>
       x-show="isVariantInCart"
-      class="animate-on-transition button button--disabled button--outline-secondary flex-grow <?= $isSmall ? 'button--size-sm' : '' ?> <?= $hasVariants ? 'max-md:hidden' : '' ?>"
+      class="
+        animate-on-transition button button--disabled button--outline-secondary flex-grow
+        <?= $isSmall ? 'button--size-sm' : '' ?>
+        <?= $hasVariants ? 'max-md:hidden' : '' ?>
+        <?= $isPopup ? 'max-sm:px-3' : '' ?>
+      "
       @click.prevent="$store.cart.showCart()"
       x-a11y-trap-target.end="$store.popup.currentPopup === productActionsPopup"
       type="button"
@@ -303,7 +309,13 @@ $cartMessage = $block->getCartMessage();
         style="display: none"
       <?php endif; ?>
       x-show="!isVariantInCart || <?= (int) $isPopup ?>"
-      class="animate-on-transition button button--disabled button--outline-secondary flex-grow <?= $isSmall ? 'button--size-sm' : '' ?> <?= ($inStock || (!$isPopup && $hasVariants)) ? 'max-md:hidden' : '' ?> <?= $inStock ? 'md:hidden' : '' ?>"
+      class="
+        animate-on-transition button button--disabled button--outline-secondary flex-grow
+        <?= $isSmall ? 'button--size-sm' : '' ?>
+        <?= ($inStock || (!$isPopup && $hasVariants)) ? 'max-md:hidden' : '' ?>
+        <?= $inStock ? 'md:hidden' : '' ?>
+        <?= $isPopup ? 'max-sm:px-3' : '' ?>
+      "
       disabled
       type="button"
     >
@@ -316,7 +328,7 @@ $cartMessage = $block->getCartMessage();
         style="display: none"
       <?php endif; ?>
       x-show="<?= (int) ($productType !== 'downloadable') ?> && (!isVariantInCart || <?= (int) $isPopup ?>)"
-      class="animate-on-transition button button--outline-primary w-full md:hidden"
+      class="animate-on-transition button button--outline-primary flex-grow md:hidden <?= $isPopup ? 'max-sm:px-3' : '' ?>"
       :class="
       {
         'max-md:hidden': !isVariantInCart || !<?= (int) $isPopup ?>

--- a/app/design/frontend/Satoshi/Hyva/Magento_Catalog/templates/product/view/product-info.phtml
+++ b/app/design/frontend/Satoshi/Hyva/Magento_Catalog/templates/product/view/product-info.phtml
@@ -132,7 +132,7 @@ $hyvaicons = $viewModels->require(SvgIcons::class);
         $popup_id = 'product_actions-' . $product->getId();
         $options = $block->getChildBlock('product.info.form') ? $block->getChildBlock('product.info.form')->setData(['is_popup' => true])->toHtml() : '';
         $options .= $block->getChildHtml('product_options_wrapper_bottom');
-        $minHeight = $product->getTypeId() === 'bundle' ? 'min-h-24' : 'min-h-20';
+        $minHeight = $product->getTypeId() === 'bundle' ? 'min-h-40' : 'min-h-20';
 
         $productActions = <<<HTML
             <template x-if="\$store.main.isMobile">

--- a/app/design/frontend/Satoshi/Hyva/Magento_Catalog/templates/product/view/quantity.phtml
+++ b/app/design/frontend/Satoshi/Hyva/Magento_Catalog/templates/product/view/quantity.phtml
@@ -98,7 +98,7 @@ $isSmall = $block->getData('is_small') ?? false;
       <?php endif; ?>
       name="qty"
       :value="variantQty || <?= $block->getProductDefaultQty() * 1 ?>"
-      class="animate-on-transition input__field flex-shrink-0 basis-14 text-center md:h-auto bg-transparent <?= $isSmall ? 'h-9 px-3' : '' ?>"
+      class="animate-on-transition input__field flex-shrink-0 basis-14 text-center md:h-auto bg-transparent <?= $isSmall ? 'h-9 px-3' : '' ?> <?= $isPopup ? 'max-sm:basis-8 max-sm:px-2' : '' ?>"
       min="1"
       @change.lazy="setQuantity($event.target.value)"
       aria-label="<?= __('Quantity') ?>"


### PR DESCRIPTION
Resolved issue: Open https://satoshi-bmk-1720548019.readymage.com/sprite-yoga-companion-kit.html product then change viewport width to 320px. then click on "Customize bundle". some part of the overlay is not visible.

Screenshot of the issue: https://monosnap.com/direct/A9vyicH2TI143VOM1pEhM57z5acKPy