### PR TITLE
INTERNAL-411-53 - Add alpinejs cdn to CSP configuration

### DIFF
--- a/app/code/Satoshi/Theme/etc/csp_whitelist.xml
+++ b/app/code/Satoshi/Theme/etc/csp_whitelist.xml
@@ -3,7 +3,7 @@
     <policies>
         <policy id="script-src">
             <values>
-                <value id="cdn.jsdelivr.net" type="host">https://cdn.jsdelivr.net</value>
+                <value id="cdn_jsdelivr_net" type="host">https://cdn.jsdelivr.net</value>
             </values>
         </policy>
     </policies>


### PR DESCRIPTION
There was always a Content Security Policy (CSP) error in the console. I resolved it by adding alpinejs cdn to the CSP configuration.

Screenshot of the issue: https://monosnap.com/direct/Ti5mvXTVt0flw5gdZ7e0SvDjP37oKZ