### PR TITLE
INTERNAL-411-66; fix menu content transition on close, and hide its content

### DIFF
--- a/app/design/frontend/Satoshi/Hyva/Magento_Theme/templates/html/header/menu/menu-items.phtml
+++ b/app/design/frontend/Satoshi/Hyva/Magento_Theme/templates/html/header/menu/menu-items.phtml
@@ -35,7 +35,8 @@ if (!$menuItems) {
     :class="{
         'menu__level--current': history[history.length - 1] === '<?= $id ?>',
         'menu__level--visible': history.includes('<?= $id ?>'),
-        'menu__level--same-depth': <?= $level ?> <= delayedLevel
+        'menu__level--same-depth': <?= $level ?> <= delayedLevel,
+        'hidden': !$store.resizable.isVisible('menu-desktop'),
     }"
     :inert="!history.includes('<?= $id ?>')"
     data-menu-level="<?= $id ?>"
@@ -52,7 +53,6 @@ if (!$menuItems) {
                         aria-label="<?= __('Close menu') ?>"
                         aria-controls="menu-desktop"
                         :aria-expanded="$store.resizable.isVisible('menu-desktop')"
-                        :class="{'hidden': !$store.resizable.isVisible('menu-desktop')}"
                     >
                         <div class="contents">
                             <?= $hyvaicons->renderHtml('close'); ?>


### PR DESCRIPTION
### The issue
When closing the menu on desktop, its content still occupies space (width and height) in the DOM, even though it's not visible. The main issue is that the close button disappears before the menu items, causing a quick layout shift before the menu is fully closed.

[Before and After preview](https://www.awesomescreenshot.com/video/34299538?key=13def645235e99ed2ecb131ef6d7ad55)