### PR TITLE
INTERNAL-411-119; fix aspect ratio to make 'add to cart' btn at bottom of the page

### DIFF
--- a/app/design/frontend/Satoshi/Hyva/Magento_Theme/templates/head/inject-variables.phtml
+++ b/app/design/frontend/Satoshi/Hyva/Magento_Theme/templates/head/inject-variables.phtml
@@ -18,7 +18,7 @@
 
     document.documentElement.style.setProperty(
       '--product-aspect-ratio',
-        (screenWidth / (screenHeight - 120)).toString(),
+      (screenWidth / (screenHeight - 120)).toString(),
     );
   };
 


### PR DESCRIPTION
## Why '120' instead of '155'?
Mahmoud identified a layout difference between Hyva and Shopify. Shopify includes a "Welcome to our store" section at the top of the page, which affects the overall page height. To align the behavior between the two platforms, I adjusted the calculator by subtracting the height of this section, which does not exist in Hyva.

### Before
![image](https://github.com/user-attachments/assets/c9578a8c-1e46-4fa6-9719-db87f861ca83)

### After
![image](https://github.com/user-attachments/assets/e3753774-ed40-49d7-9301-80c5057d8aa2)

### Shopify
![image](https://github.com/user-attachments/assets/a56da654-1ca8-4c29-aef3-def1c4a16259)
