### PR TITLE
INTERNAL-411-46 - Styling details overlay in wishlist page

### DIFF
--- a/app/design/frontend/Satoshi/Hyva/Magento_Theme/templates/html/header/cart/minicart-items.phtml
+++ b/app/design/frontend/Satoshi/Hyva/Magento_Theme/templates/html/header/cart/minicart-items.phtml
@@ -80,8 +80,8 @@ $mixBackground = true;
                   :key="o"
                 >
                   <p
-                      class="text-[14px]"
-                    x-html="`${option.label}: ${option.value}`"
+                    class="text-[14px]"
+                    x-html="`${option.label}: ${Array.isArray(option.value) ? option.value.join(', ') : option.value}`"
                   ></p>
                 </template>
               </template>

--- a/app/design/frontend/Satoshi/Hyva/Magento_Theme/templates/html/header/wishlist/wishlist-items.phtml
+++ b/app/design/frontend/Satoshi/Hyva/Magento_Theme/templates/html/header/wishlist/wishlist-items.phtml
@@ -56,8 +56,8 @@ $mixBackground = true;
                   :key="o"
                 >
                   <p
-                      class="text-[14px]"
-                    x-html="`${option.label}: ${option.value}`"
+                    class="text-[14px]"
+                    x-html="`${option.label}: ${Array.isArray(option.value) ? option.value.join(', ') : option.value}`"
                   ></p>
                 </template>
               </template>

--- a/app/design/frontend/Satoshi/Hyva/Magento_Wishlist/templates/item/column/price.phtml
+++ b/app/design/frontend/Satoshi/Hyva/Magento_Wishlist/templates/item/column/price.phtml
@@ -7,14 +7,20 @@ use Magento\Wishlist\Block\Customer\Wishlist\Item\Column\Cart;
 /** @var Item $item */
 $item = $block->getItem();
 $product = $item->getProduct();
+$shouldRenderQtyInput = $item->canHaveQty() && $product->isVisibleInSiteVisibility();
 ?>
 
-<div class="flex justify-between items-center mb-5 [&_.price]:text-text-500 [&_.price]:text-lg [&_.price]:font-bold">
+<div
+    class="
+        flex justify-between items-center mb-5 [&_.price-box_.price]:text-text-500 [&_.price-box_.price]:text-lg [&_.price-box_.price]:font-bold
+        <?= $shouldRenderQtyInput ? '[&_.product-details-tooltip]:-translate-x-[60%]' : '[&_.product-details-tooltip]:-translate-x-full' ?>
+    "
+>
     <?php foreach ($block->getChildNames() as $childName): ?>
         <?= /* @noEscape */ $block->getLayout()->renderElement($childName, false) ?>
     <?php endforeach;?>
 
-    <?php if ($item->canHaveQty() && $product->isVisibleInSiteVisibility()): ?>
+    <?php if ($shouldRenderQtyInput): ?>
         <label
             class="sr-only"
             for="qty[<?= $escaper->escapeHtmlAttr($item->getId()) ?>]"

--- a/app/design/frontend/Satoshi/Hyva/Magento_Wishlist/templates/options_list.phtml
+++ b/app/design/frontend/Satoshi/Hyva/Magento_Wishlist/templates/options_list.phtml
@@ -1,0 +1,67 @@
+<?php
+
+use Magento\Framework\Escaper;
+use Magento\Wishlist\Block\Customer\Wishlist\Item\Options;
+
+/** @var Options $block */
+/** @var Escaper $escaper */
+?>
+
+<?php $options = $block->getOptionList(); ?>
+<?php if ($options): ?>
+    <div class="items-center justify-start flex tooltip my-2">
+        <div
+            x-data="{
+                showTooltip: false,
+                tooltipId: $id('product-details-tooltip')
+            }"
+            class="relative z-30 inline-flex"
+        >
+            <button
+                type="button"
+                @mouseover.prevent.stop="showTooltip = true"
+                @mouseleave.prevent.stop="showTooltip = false"
+                @focus="showTooltip = true"
+                @focusout="showTooltip = false"
+                @keydown.escape="showTooltip = false"
+                :aria-labelledby="tooltipId"
+            >
+                <?= $escaper->escapeHtml(__('See Details')) ?>
+            </button>
+            <div class="relative" x-cloak x-show="showTooltip">
+                <div class="shadow-lg">
+                    <div
+                        :id="tooltipId"
+                        class="
+                            product-details-tooltip absolute top-0 left-0 z-10 w-64 -mt-6 text-sm
+                            transform -translate-y-full bg-white rounded-lg shadow-lg p-4
+                        "
+                    >
+                        <span class="text-lg font-semibold text-text-500 leading-tight">
+                            <?= $escaper->escapeHtml(__('Options Details')) ?>
+                        </span>
+                        <div class="my-2">
+                            <?php foreach ($options as $option): ?>
+                                <p class="text-[14px]">
+                                    <?= $escaper->escapeHtml($option['label'] . ':') ?>
+                                    <?php if (is_array($option['value'])): ?>
+                                        <?= /* @noEscape */ implode(", ", $option['value']) ?>
+                                    <?php else: ?>
+                                        <?= /* @noEscape */ $option['value'] ?>
+                                    <?php endif; ?>
+                                </p>
+                            <?php endforeach; ?>
+                        </div>
+                    </div>
+                    <svg
+                        class="absolute z-10 w-8 h-8 text-white transform -translate-x-full -translate-y-8 fill-current stroke-current"
+                        width="12"
+                        height="12"
+                    >
+                        <rect x="12" y="-12" width="12" height="12" transform="rotate(45)" class="shadow-xl" />
+                    </svg>
+                </div>
+            </div>
+        </div>
+    </div>
+<?php endif ?>


### PR DESCRIPTION
Add a product (with selected attributes) to wishlist then go to wishlist page. the "See Details" popup doesn't look good. 

Here are the issues (some found during development):
- Make attributes look like in minicart
- Details overlay goes outside of the viewport in some situations
- Add "Sprite Yoga Companion Kit" to the wishlist and open the details overlay. the price style has issue.
- If we have multiple options for an attribute, then there is no space between them. we have the same issue even in minicart, wishlist overlay and cart page

https://monosnap.com/direct/2myK4rWMfHzviqNut5oqyrlUctzxSK
https://monosnap.com/direct/9pH3SORzp8h6UqyuE4V8rCHli7jD4W
https://monosnap.com/direct/FgXenuOs6F4YnAHXb68uSv8TX2XyXz