### PR TITLE
INTERNAL-411-120 - Fix image size issue in wishlist card

### DIFF
--- a/app/design/frontend/Satoshi/Hyva/Magento_Wishlist/templates/item/column/image.phtml
+++ b/app/design/frontend/Satoshi/Hyva/Magento_Wishlist/templates/item/column/image.phtml
@@ -10,15 +10,18 @@ use Magento\Wishlist\Model\Item;
 /** @var Item $item */
 $item = $block->getItem();
 $product = $item->getProduct();
+$imageUrl = $block->getImage($block->getProductForThumbnail($item), 'wishlist_thumbnail')->getImageUrl();
 ?>
 <a
-    class="
-        flex items-center justify-center overflow-hidden rounded-xl bg-[--fade-in-bg] mb-5
-        [&_img]:mix-blend-darken [&_img]:object-center [&_img]:max-h-full [&_img]:object-cover [&_img]:h-full [&_img]:w-full
-    "
+    class="flex overflow-hidden rounded-xl bg-[--fade-in-bg] aspect-product mb-5"
     tabindex="-1"
     href="<?= $escaper->escapeUrl($block->getProductUrl($item)) ?>"
     title="<?= $escaper->escapeHtmlAttr($product->getName()) ?>"
 >
-    <?= $block->getImage($block->getProductForThumbnail($item), 'wishlist_thumbnail')->toHtml() ?>
+    <img
+        class="mix-blend-darken object-center object-cover h-full w-full"
+        src="<?= $escaper->escapeUrl($imageUrl) ?>"
+        alt="<?= $escaper->escapeHtmlAttr($product->getName()) ?>"
+        loading="lazy"
+    />
 </a>

--- a/app/design/frontend/Satoshi/Hyva/Magento_Wishlist/templates/item/list.phtml
+++ b/app/design/frontend/Satoshi/Hyva/Magento_Wishlist/templates/item/list.phtml
@@ -10,7 +10,7 @@ $columns = $block->getColumns();
 
 <div>
     <?php if (count($block->getItems())): ?>
-    <ol class="grid gap-5 grid-cols-1 md:grid-cols-1 lg:grid-cols-2 xl:grid-cols-3" data-content-wrapper>
+    <ol class="grid gap-5 grid-cols-1 sm:grid-cols-2 md:grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4" data-content-wrapper>
         <!-- pagination-content -->
         <?php foreach ($block->getItems() as $item): ?>
             <li


### PR DESCRIPTION
Issue: On the wishlist page, if a product doesn't have any image, the default image height is not consistent with other images.
Screenshot of the issue: https://monosnap.com/direct/loO4Gy6P2WGWzUYRab8SrQqaxoWeBw
Fix: I set the aspect ratio to the wishlist card image and also modified the number of grid columns in different screen sizes.