### PR TITLE
INTERNAL-389 - Fix search box spacing issue on IOS

### DIFF
--- a/app/design/frontend/Satoshi/Hyva/Magento_Theme/templates/html/header/search/search-products.phtml
+++ b/app/design/frontend/Satoshi/Hyva/Magento_Theme/templates/html/header/search/search-products.phtml
@@ -23,7 +23,7 @@ use Satoshi\Theme\Block\Template;
     </p>
     <div
       x-show="products.length"
-      class="grid grid-cols-2 gap-5 md:grid-cols-3 lg:grid-cols-4"
+      class="grid grid-cols-2 gap-5 content-start md:grid-cols-3 lg:grid-cols-4"
       x-transition.opacity
       x-transition.duration.700ms
     >


### PR DESCRIPTION
Issue: On mobile (IOS), there is redundant space between product SKU and price in the search box
Screenshot of the issue: https://prnt.sc/FZuxcDFNr9se