### PR TITLE
INTERNAL-411-56; fix configurable out-of-stock variant's style in PDP

### DIFF
--- a/app/design/frontend/Satoshi/Hyva/Magento_Swatches/templates/product/swatch-item.phtml
+++ b/app/design/frontend/Satoshi/Hyva/Magento_Swatches/templates/product/swatch-item.phtml
@@ -31,7 +31,8 @@ $isPopup = $block->getData('is_popup') ?? false;
         @click="optionIsActive(<?= (int)$attributeId ?>, item.id) && changeOption(<?= (int)$attributeId ?>, item.id)"
         class="button button--size-sm select-none transition-all ease-in-out relative bg-bg-500"
         :class="{
-            'button--outline-primary border-2 button--disabled !opacity-100': selectedValues[<?= (int)$attributeId ?>] === item.id || !optionIsActive(<?= (int)$attributeId ?>, item.id),
+            'button--outline-primary button--disabled': !optionIsActive(<?= (int)$attributeId ?>, item.id),
+            'button--outline-primary border-2': selectedValues[<?= (int)$attributeId ?>] === item.id,
             'button--outline-secondary': selectedValues[<?= (int)$attributeId ?>] !== item.id,
         }"
         role="radio"


### PR DESCRIPTION
After:
![image](https://github.com/user-attachments/assets/5156ffe8-6355-4a67-8508-a81a30eada56)
