### PR TITLE
INTERNAL-411-162; fix 'Uncaught x-a11y-radio can only be used on elements of 'radio' role' console error when selecting PDP's variant

### DIFF
--- a/app/design/frontend/Satoshi/Hyva/Magento_Swatches/templates/product/swatch-item.phtml
+++ b/app/design/frontend/Satoshi/Hyva/Magento_Swatches/templates/product/swatch-item.phtml
@@ -28,7 +28,7 @@ $isPopup = $block->getData('is_popup') ?? false;
 <template x-if="optionIsEnabled(<?= (int)$attributeId ?>, item.id)">
     <label
         :for="`attribute-option-<?= (int)$productId ?>-${item.id}-<?= $isPopup ? 'mobile' : 'desktop' ?>`"
-        @click.stop.prevent="optionIsActive(<?= (int)$attributeId ?>, item.id) && changeOption(<?= (int)$attributeId ?>, item.id)"
+        @click.stop="optionIsActive(<?= (int)$attributeId ?>, item.id) && changeOption(<?= (int)$attributeId ?>, item.id)"
         class="button button--size-sm select-none transition-all ease-in-out relative bg-bg-500"
         :class="{
             'button--outline-primary button--disabled': !optionIsActive(<?= (int)$attributeId ?>, item.id),

--- a/app/design/frontend/Satoshi/Hyva/web/satoshi/src/plugins/Accessibility.ts
+++ b/app/design/frontend/Satoshi/Hyva/web/satoshi/src/plugins/Accessibility.ts
@@ -190,7 +190,11 @@ export default function (Alpine: AlpineType) {
       if (
         !e.target ||
         !(e.target instanceof HTMLElement) ||
-        e.target.role !== "radio"
+        (
+          e.target.tagName === "INPUT"
+            ? e.target.parentElement?.role !== "radio"
+            : e.target.role !== "radio"
+        )
       ) {
         throw "x-a11y-radio can only be used on elements of 'radio' role";
       }


### PR DESCRIPTION
### **Related Files:**  
- `app/design/frontend/Satoshi/Hyva/Magento_Swatches/templates/product/swatch-item.phtml`  
- `app/design/frontend/Satoshi/Hyva/web/satoshi/src/plugins/Accessibility.ts`  

---

### **Issue Overview**  
An error was observed in the console on PDP when users interacted with product variants:  
![Error Image](https://github.com/user-attachments/assets/12a6c0da-7a45-4a61-95a4-e0d13f56194e)

This error occurred under specific scenarios:  
1. When users **clicked** on a product variant and then pressed a **key** (e.g., Tab or arrow keys), the `x-a11y-radio` directive threw the following error:  
   ```
   Uncaught x-a11y-radio can only be used on elements of 'radio' role
   ```
2. **Keyboard-only navigation** (e.g., using Tab) functioned correctly, as the directive handled focus appropriately when no mouse click was involved.  

The issue stemmed from a misalignment between the `x-a11y-radio` directive’s validation logic and the browser's handling of `<label>` and `<input>` interactions.  

---

### **Error Source**  
The root cause was identified in the following condition within the `x-a11y-radio` directive:  
```typescript
e.target.role !== "radio"
```  

When users interacted with a `<label>` wrapping an `<input>`, the validation failed due to the following:  

1. **Browser Behavior:**  
   - Clicking a `<label>` automatically forwards focus to its nested `<input>`.  
   - The `e.target` in the event becomes the `<input>`, which lacks the `role="radio"` that is typically assigned to the parent `<label>`.  

2. **Validation Mismatch:**  
   - The directive assumed that `e.target` would always have the `role="radio"`. When the target was the `<input>`, this assumption broke, resulting in the error.  

3. **Previous Workaround Attempt:**  
   - Adding `pointer-events: none;` to the `<input>` was tested but proved ineffective, as the browser still programmatically forwarded the click event to the `<input>`.  

---

### **Solution**  
The validation logic in the `x-a11y-radio` directive was updated to handle nested `<input>` elements while preserving accessibility standards.  

#### **Updated Directive Logic:**  
The original condition:  
```typescript
if (!e.target || !(e.target instanceof HTMLElement) || e.target.role !== "radio") {
  throw "x-a11y-radio can only be used on elements of 'radio' role";
}
```  

The updated condition:  
```typescript
if (
  !e.target ||
  !(e.target instanceof HTMLElement) ||
  (
    e.target.tagName === "INPUT"
      ? e.target.parentElement?.role !== "radio"
      : e.target.role !== "radio"
  )
) {
  throw "x-a11y-radio can only be used on elements of 'radio' role";
}
```  

#### **Key Changes:**  
- When the `e.target` is an `<input>`, the validation now checks the `role` of its parent element (usually the `<label>`).  
- This ensures compatibility with nested input structures and maintains proper handling for other elements.  

---

### **Outcome**  
The updated logic resolves the error without compromising accessibility compliance or user interactions. Attached screenshots demonstrate the issue resolution:  
![Fixed Behavior Screenshot](https://github.com/user-attachments/assets/98dd702b-b08a-40b7-9110-23db4eafb61b)
