### PR TITLE
INTERNAL-411-173; Fix: 'Change Password' btn style

### DIFF
--- a/app/design/frontend/Satoshi/Hyva/Magento_Customer/templates/account/dashboard/info.phtml
+++ b/app/design/frontend/Satoshi/Hyva/Magento_Customer/templates/account/dashboard/info.phtml
@@ -30,7 +30,7 @@ $errorMessage = $block->getErrorMessage();
     <?= $escaper->escapeHtml(__('Account Information')) ?>
 </h2>
 <div class="grid gap-5 lg:gap-8 grid-cols-1 lg:grid-cols-2">
-    <div class="bg-bg-400 p-7 rounded-xl flex flex-col md:flex-row gap-4 md:gap-5 overflow-x-auto">
+    <div class="bg-bg-400 p-7 rounded-xl flex flex-col md:flex-row gap-4 md:gap-5">
         <div class="self-start flex items-center align-center gap-4">
             <div class="p-4 text-primary-500 bg-bg-500 rounded-xl">
                 <?= $hyvaicons->renderHtml('user', 'w-6 h-6') ?>
@@ -63,13 +63,13 @@ $errorMessage = $block->getErrorMessage();
                     href="<?= $escaper->escapeUrl($block->getChangePasswordUrl()) ?>"
                     x-element-transition-trigger
                 >
-                    <?= $escaper->escapeHtml(__('Change Password')) ?>
+                    <?= $escaper->escapeHtml(__('Edit Password')) ?>
                 </a>
             </div>
         </div>
     </div>
     <?php if ($block->isNewsletterEnabled()): ?>
-        <div class="bg-bg-400 p-7 rounded-xl flex flex-col md:flex-row gap-4 md:gap-5 overflow-x-auto">
+        <div class="bg-bg-400 p-7 rounded-xl flex flex-col md:flex-row gap-4 md:gap-5">
             <div class="self-start flex items-center align-center gap-4">
                 <div class="p-4 text-primary-500 bg-bg-500 rounded-xl">
                     <?= $hyvaicons->renderHtml('envelope', 'w-6 h-6') ?>


### PR DESCRIPTION
### Before
![image](https://github.com/user-attachments/assets/35ca768d-0a68-418e-81f1-416dafdc1ed2)

### After
![image](https://github.com/user-attachments/assets/657409be-93ae-4892-ba5e-d8646a228fa9)

Kindly check other possible solutions on [this](https://scandiweb.slack.com/archives/C06CATK5JFP/p1735758674847659?thread_ts=1735758623.367589&cid=C06CATK5JFP) thread.

### Note
Both 'Edit' and 'Change Password' can make the same exact action
![image](https://github.com/user-attachments/assets/d2d7e91f-a6bb-4308-a49a-f9d3963faf3b)
except for 'Change Password' it checks on 'change password', that's why I preferred this solution to the issue, as both open the same form.

---

### Updated Solution
Since the text might be changed on changing locale
![image](https://github.com/user-attachments/assets/585fc46f-8dcc-4835-b6ea-f999f799deec)
