### PR TITLE
INTERNAL-411-48: update price class in minicart to be consistent with price in wishlist and other places

### DIFF
--- a/app/design/frontend/Satoshi/Hyva/Magento_Theme/templates/html/header/cart/minicart-items.phtml
+++ b/app/design/frontend/Satoshi/Hyva/Magento_Theme/templates/html/header/cart/minicart-items.phtml
@@ -99,7 +99,7 @@ $mixBackground = true;
                                 <?= $template->setData('for_cart_page', false)->render('Magento_Theme::html/header/cart/minicart-quantity-controls.phtml') ?>
                             </div>
                             <div
-                                class="flex flex-col items-center justify-between text-md text-primary-500 <?= $isCartPage ? 'md:items-start mt-3' : '' ?>"
+                                class="price <?= $isCartPage ? 'mt-3' : '' ?>"
                                 x-text="hyva.formatPrice(item.product_price_value)">
                             </div>
                         </div>


### PR DESCRIPTION
At first I was going to change the price class in wishlist resizable, but after searching for `price` class, I found it was used for the prices in different locations
![image](https://github.com/user-attachments/assets/336dc32b-7322-4748-bbab-a686fa407c19)
So I changed it in minicart resizable instead
 
---

### Before
![image](https://github.com/user-attachments/assets/c403838b-cb75-4698-b0aa-a4e97b532da9)

### After
![image](https://github.com/user-attachments/assets/af4ab121-4499-4a64-ab68-19e3a3c76487)
