### PR TITLE
INTERNAL-411-179; Fix duplicated #MainContent on page transitioning

### DIFF
--- a/app/design/frontend/Satoshi/Hyva/Magento_Theme/templates/html/layout/main-content.phtml
+++ b/app/design/frontend/Satoshi/Hyva/Magento_Theme/templates/html/layout/main-content.phtml
@@ -17,7 +17,6 @@ $class = match($page_type) {
 
 ?>
 
-<!-- main-content -->
 <main id="MainContent"
       class="content-for-layout focus-none flex h-full origin-top flex-col transition-transform duration-500 will-change-transform motion-reduce:transition-none"
       :class="{
@@ -32,7 +31,8 @@ $class = match($page_type) {
         }"
       @scroll.window="$store.main.setTransformValues"
 >
+    <!-- main-content -->
     <div class="<?= $class ?>"></div>
     <?= $block->getChildHtml() ?>
+    <!-- end-main-content -->
 </main>
-<!-- end-main-content -->


### PR DESCRIPTION
### The Issue
When implementing internal page transitions, the `replaceMainContent` function caused a duplication of the `<main id="MainContent">` element on the first redirect.

![image](https://github.com/user-attachments/assets/affa3214-c60e-4c7c-b174-ea6b4fc7d696)

---

### Reason
The issue occurred because the `replaceContent` function replaced the `innerHTML` of the existing `<main id="MainContent">` element with new content. The AJAX response (`rawContent`) already included the `<main id="MainContent">` structure. This caused a new `<main id="MainContent">` to be nested inside the existing one, leading to duplication.

---

### Solution
The HTML comments `<!-- main-content -->` and `<!-- end-main-content -->` were moved inside the `<main>` element. This ensured that the `replaceContent` and `replaceMainContent` functions correctly targeted and replaced only the content within `<main>`. As a result, the parent `<main>` element was preserved, and duplication was avoided. 

---

### Outcome
- **No Duplication:** The `<main>` element remains singular across all redirects.

![image](https://github.com/user-attachments/assets/38924629-3b51-4173-acbc-201831c1da72)
