### PR TITLE
INTERNAL-411-183 - Fix logo size issue on mobile

### DIFF
--- a/app/design/frontend/Satoshi/Hyva/Magento_Theme/templates/html/header/logo.phtml
+++ b/app/design/frontend/Satoshi/Hyva/Magento_Theme/templates/html/header/logo.phtml
@@ -51,7 +51,7 @@ $estimated_width = $text_length * 12;
     <!-- Mobile logo -->
     <img
         class="object-contain h-[32px] w-auto md:hidden"
-        style="max-width: <?= $logoWidth > 500 ? 500 : $logoWidth ?>px"
+        style="max-width: <?= $logoWidth > 96 ? 96 : $logoWidth ?>px"
         src="<?= $escaper->escapeUrl($logoSrc) ?>"
         alt="<?= $escaper->escapeHtmlAttr($block->getLogoAlt() ? $block->getLogoAlt() : $storeName) ?>"
         width="<?= $escaper->escapeHtmlAttr($logoWidth ?? 200) ?>"


### PR DESCRIPTION
Issue: On 320px, the cart logo placement in header is not correct. probably the issue is for the logo size

Screenshot of the issue: https://monosnap.com/file/S5erxd3HR0bLPfE0hvFVeQkuHxlkRl

Screenshot after the fix: https://monosnap.com/direct/vU9UTYG7Dkw9CZKaevBgIMgkg7czoZ