### PR TITLE
INTERNAL-411-64 - Prevent body scroll when search results are active

### DIFF
--- a/app/design/frontend/Satoshi/Hyva/Magento_Theme/templates/html/header/search/search.phtml
+++ b/app/design/frontend/Satoshi/Hyva/Magento_Theme/templates/html/header/search/search.phtml
@@ -79,7 +79,6 @@ $hyvaicons = $viewModels->require(SvgIcons::class);
     </form>
 
     <div
-        x-init="() => setSearchResultsElement($el)"
         x-show="getIsSearchActive()"
         class="flex flex-col gap-3 overflow-x-hidden pt-2 transition-opacity duration-0 md:inset-x-0 md:top-full md:max-h-[calc(100dvh-125px)] md:rounded-t-none md:pt-0 md:duration-300 md:rounded-none"
         x-transition:enter="md:delay-450"

--- a/app/design/frontend/Satoshi/Hyva/web/satoshi/src/data/Search.ts
+++ b/app/design/frontend/Satoshi/Hyva/web/satoshi/src/data/Search.ts
@@ -1,7 +1,6 @@
 import type { Magics } from "alpinejs";
 import { navigateWithTransition } from "../plugins/Transition";
 import { searchQuery } from "../graphql/searchQuery";
-import { freezeScroll, makeElementScrollable, unfreezeScroll } from "../utils/scroll2";
 
 export type SearchType = {
   [key: string | symbol]: any;
@@ -14,7 +13,6 @@ export type SearchType = {
   categories: [];
   isNoResults: boolean;
   productsSearchLimit: number;
-  searchResultsElement: HTMLElement;
 
   init(): void;
   getIsSearchActive(): boolean;
@@ -23,7 +21,6 @@ export type SearchType = {
   search(): void;
   getSearchUrl(path: string): string;
   goToSearchPage(path: string): void;
-  setSearchResultsElement(element: HTMLElement): void;
 } & Magics<{}>;
 
 const initialSearch = new URLSearchParams(window.location.search).get("q");
@@ -43,12 +40,11 @@ export const Search = () =>
       const isSearchActive = !!this.searchTerm.length;
 
       if (isSearchActive) {
-        freezeScroll();
-        makeElementScrollable(this.searchResultsElement);
+        document.body.style.overflow = 'hidden';
       }
 
       if (!isSearchActive || !this.$store.resizable.isVisible('search-desktop')) {
-        unfreezeScroll();
+        document.body.style.overflow = '';
       }
 
       return isSearchActive;
@@ -123,9 +119,5 @@ export const Search = () =>
       return this.searchTermInput
         ? `${path}?q=${encodeURIComponent(this.searchTermInput.trim())}`
         : path;
-    },
-
-    setSearchResultsElement(element) {
-      this.searchResultsElement = element;
     },
   };


### PR DESCRIPTION
### Summary

To prevent the body from scrolling when the search resizable is open, I initially updated the `default.xml` file in  
`app/design/frontend/Satoshi/Hyva/Magento_Theme/layout` as follows:

```xml
<attribute name=":class" value="{'overflow-hidden': $store.resizable.isVisible('search-desktop')}"/>
```

However, we decided to enhance the behavior further by preventing scroll only when search results are active. This was achieved using the `freezeScroll` method.

---

### Changes

1. Introduced logic to conditionally apply `freezeScroll` based on whether search results are active.
2. Created a cached `searchResultsElement` to avoid repeatedly querying the DOM with `makeElementScrollable(document.getElementById("search-results"))`.

---

### Reason for Creating `searchResultsElement`

The `getIsSearchActive` method was being triggered multiple times on each keypress during search. Using `searchResultsElement` reduces unnecessary DOM queries, improving performance and preventing redundant operations.

![Screenshot from 2025-01-15 13-18-35](https://github.com/user-attachments/assets/14580baa-8061-467d-8104-042df21a526d)

![Screenshot from 2025-01-15 13-17-51](https://github.com/user-attachments/assets/d98a442e-b34b-4ec1-a6c9-6c84434a9de7)

---

### Demo After Change

https://github.com/user-attachments/assets/dfb68e5a-b87f-48f4-ad9d-5d7843a3634b

---

### Update

After CR, I refactored search scroll behavior to use `body.overflow` for scroll lock.
