### PR TITLE
INTERNAL-411-188 - Truncate category title

### DIFF
--- a/app/design/frontend/Satoshi/Hyva/Magento_Theme/templates/html/header/menu/menu-items.phtml
+++ b/app/design/frontend/Satoshi/Hyva/Magento_Theme/templates/html/header/menu/menu-items.phtml
@@ -82,6 +82,7 @@ if (!$menuItems) {
                 style="--translate-width: 52px;"
                 :class="{
                     'menu__heading--root': '<?= $id ?>' === 'all',
+                    'max-md:w-[calc(100%-var(--translate-width))]': '<?= $id ?>' !== 'all',
                     'max-md:animate-slideTitleIn motion-reduce:translate-x-[--translate-width]': history.length !== 1,
                     'max-md:animate-slideTitleOut motion-reduce:translate-x-0': history.length == 1
                 }"

--- a/app/design/frontend/Satoshi/Hyva/web/satoshi/theme/components/_menu.scss
+++ b/app/design/frontend/Satoshi/Hyva/web/satoshi/theme/components/_menu.scss
@@ -84,7 +84,7 @@
   }
 
   &__heading {
-    @apply translate-x-[52px] text-lg text-text-500 transition-transform duration-300;
+    @apply truncate translate-x-[52px] text-lg text-text-500 transition-transform duration-300;
 
     @screen md {
       @apply flex-1 translate-x-0 text-md;


### PR DESCRIPTION
The 1st issue: Open "Home & Interior" category from menu. the title is in 2 lines which is not good. to fix it truncate the title.
Screenshot of the 1st issue: https://monosnap.com/file/9uYoynmdubzalxvpAk7kwdw3DpemQr

The 2nd issue: While I was working on this task, I found another issue related to width of the category title element on mobile. because we have translate-x there, the title goes outside of its container.
Screenshot of the 2nd issue: https://monosnap.com/file/AWp7SJ8TMsnFKjHm1iUBd2QMpq7qpc