### PR TITLE
INTERNAL-411-193 - Fix search resizable height recalculated and products display

### DIFF
--- a/app/design/frontend/Satoshi/Hyva/Magento_Theme/templates/html/header/search/search-categories.phtml
+++ b/app/design/frontend/Satoshi/Hyva/Magento_Theme/templates/html/header/search/search-categories.phtml
@@ -16,7 +16,7 @@ $categoryUrlSuffix = $breadcrumbsViewModel->getCategoryUrlSuffix();
 <div
     x-show="searchTerm.length > 2"
     :class="{
-        'opacity-0': isLoading,
+        'opacity-0': isLoading && !getIsSearchActive(),
     }"
 >
     <div class="relative flex grow flex-col gap-4 p-3 pb-2 md:p-5">

--- a/app/design/frontend/Satoshi/Hyva/Magento_Theme/templates/html/header/search/search-products.phtml
+++ b/app/design/frontend/Satoshi/Hyva/Magento_Theme/templates/html/header/search/search-products.phtml
@@ -12,7 +12,7 @@ use Satoshi\Theme\Block\Template;
 <div
     class="transition overflow-hidden"
     :class="{
-        'opacity-0': isLoading,
+        'opacity-0': isLoading && !getIsSearchActive(),
     }"
 >
     <div class="flex grow flex-col gap-4 p-3 pb-2 md:p-5">
@@ -24,7 +24,7 @@ use Satoshi\Theme\Block\Template;
                 <b class="font-semibold text-secondary-700"><?= __('Oops!') ?></b>
                 <?= __('We could not find any products matching your search.') ?>
             </p>
-            <p x-show="searchTerm.length < 3">
+            <p x-show="searchTerm.length < 3 && !isLoading">
                 <?= __('Minimum Search query length is 3') ?>
             </p>
             <div

--- a/app/design/frontend/Satoshi/Hyva/Magento_Theme/templates/html/header/search/search-suggestions.phtml
+++ b/app/design/frontend/Satoshi/Hyva/Magento_Theme/templates/html/header/search/search-suggestions.phtml
@@ -1,7 +1,7 @@
 <div
     x-show="suggestions.length"
     :class="{
-        'opacity-0': isLoading,
+        'opacity-0': isLoading && !getIsSearchActive(),
     }"
 >
     <div class="relative flex grow flex-col gap-4 p-3 pb-2 md:p-5">


### PR DESCRIPTION
### Brief Summary of the Issue
The main issue was inconsistent rendering of the search results due to height recalculations and a text element briefly appearing before the resizable container closed. These problems have been fixed, ensuring all sections render seamlessly and without flickering or abrupt shifts.

---

1. **Initial Display Issue:**
   The first video [link](https://github.com/user-attachments/assets/798f1881-1bc1-477b-aaa0-0b7b8867c2c7) demonstrates the before and after of the initial issue where the calculated height caused visual inconsistencies during search.

2. **Intermediate Issue:**
   While fixing the display issue, another issue was identified during testing. A text element from the products template was briefly visible before the resizable container was closed, as shown in the second video [link](https://github.com/user-attachments/assets/f7ad055f-c91f-417a-8bc8-efbc06d7dd6b).

3. **Final Fix:**
   Both issues were resolved, as demonstrated in the final video [link](https://github.com/user-attachments/assets/c6e5d780-490a-4681-aa12-1c56fc1ceece). The search component now behaves as expected.
