### PR TITLE
Fix review's pagination, and bg color of empty start icon

### DIFF
--- a/app/design/frontend/Satoshi/Hyva/Magento_Review/templates/product/view/list.phtml
+++ b/app/design/frontend/Satoshi/Hyva/Magento_Review/templates/product/view/list.phtml
@@ -104,7 +104,7 @@ $productName = $block->getProduct()->getName();
                                                 <?php endwhile; ?>
                                                 <?php $i = 0; ?>
                                                 <?php while ($i < $starsEmpty): ?>
-                                                    <?= $hyvaicons->renderHtml('star', 'text-xl text-secondary-400') ?>
+                                                    <?= $hyvaicons->renderHtml('star', 'text-xl text-secondary-700') ?>
                                                     <?php $i++; ?>
                                                 <?php endwhile; ?>
                                             </div>


### PR DESCRIPTION
Fixed the pagination for reviews and adjusted the background color of the empty star icons. The color now matches the empty stars used in the overall rating at the top of the product detail page (PDP).

![image](https://github.com/user-attachments/assets/fbf5a97f-c1ed-4acb-aced-578b9979d1c3)
![image](https://github.com/user-attachments/assets/6af91388-d033-4559-a472-1aef72d258f4)
