### PR TITLE
INTERNAL-520 - Fix console errors when switching from mobile to desktop

### DIFF
--- a/app/design/frontend/Satoshi/Hyva/Magento_Catalog/templates/navigation/left.phtml
+++ b/app/design/frontend/Satoshi/Hyva/Magento_Catalog/templates/navigation/left.phtml
@@ -63,7 +63,7 @@ if (!$count) {
                 </div>
 
                 <!-- Desktop categories -->
-                <template x-if="!$store.main.isMobile">
+                <template x-if="!$store.main.isMobile && isDesktopContentInitialized">
                     <!-- Desktop Sort -->
                     <fieldset
                         class="flex-1 max-md:hidden"

--- a/app/design/frontend/Satoshi/Hyva/Magento_LayeredNavigation/templates/layer/view.phtml
+++ b/app/design/frontend/Satoshi/Hyva/Magento_LayeredNavigation/templates/layer/view.phtml
@@ -51,7 +51,7 @@ if ($sorter) {
             >
                 <?= $block->getChildBlock('state')->setData(['selected_sort' => $selectedSort])->toHtml() ?>
 
-                <template x-if="!$store.main.isMobile">
+                <template x-if="!$store.main.isMobile && isDesktopContentInitialized">
                     <div class="contents">
                         <!-- Desktop Sort -->
                         <fieldset class="flex-1 md:border-t md:border-bg-600 md:py-5 max-md:hidden" x-data="Accordion(true, 300)">

--- a/app/design/frontend/Satoshi/Hyva/web/satoshi/src/data/Filters.ts
+++ b/app/design/frontend/Satoshi/Hyva/web/satoshi/src/data/Filters.ts
@@ -12,8 +12,10 @@ export type FiltersType = {
   currentFilterValue: string;
   appliedFilterUrl: string;
   isTopFilterVisible: null | boolean;
+  isDesktopContentInitialized: boolean;
 
   init(): void;
+  initDesktopContent(): void;
   setupPopupWatcher(): void;
   selectSort(sortKey: string, sortDir: string): void;
   applySort(): void;
@@ -85,10 +87,20 @@ export const Filters = (
     appliedFilterUrl: "",
     currentFilterValue: "",
     isTopFilterVisible: null,
+    isDesktopContentInitialized: false,
 
     init() {
       this.loadSelectedFilters();
       this.setupPopupWatcher();
+      // By calling initDesktopContent method here we ensure that when switching from mobile to desktop
+      // the desktop content gets initialized after Filters component is initialized
+      this.initDesktopContent();
+    },
+
+    initDesktopContent() {
+      if (!Alpine.store("main").isMobile && !this.isDesktopContentInitialized) {
+        this.isDesktopContentInitialized = true;
+      }
     },
 
     setupPopupWatcher() {


### PR DESCRIPTION
Issue screenshot: https://monosnap.com/file/iACG3AH5fWg75XtJkGrocIPS8F2bQb

Jira ticket: https://scandiflow.atlassian.net/browse/INTERNAL-520

What I did to solve the issue: Ensure that when switching from mobile to desktop the desktop content gets initialized after Filters component is initialized