### PR TITLE
Fix menu close button spacing issue

### DIFF
--- a/app/design/frontend/Satoshi/Hyva/Magento_Theme/templates/html/header/menu/menu-items.phtml
+++ b/app/design/frontend/Satoshi/Hyva/Magento_Theme/templates/html/header/menu/menu-items.phtml
@@ -49,7 +49,7 @@ if (!$menuItems) {
                     <button
                         @click="$store.resizable.hideAll();"
                         type="button"
-                        class="button icon-button icon-button--size-lg h-auto w-auto gap-3 px-2 py-3 text-primary-500 hover:bg-bg-600"
+                        class="button icon-button icon-button--size-lg h-auto w-auto gap-3 pl-2 pr-[10px] py-3 text-primary-500 hover:bg-bg-600"
                         aria-label="<?= __('Close menu') ?>"
                         aria-controls="menu-desktop"
                         :aria-expanded="$store.resizable.isVisible('menu-desktop')"


### PR DESCRIPTION
Ticket: No ticket provided yet

Issue: Close icon small misalignment, offset on the left side much bigger than on the right side

Changed this:

![image](https://github.com/user-attachments/assets/bd925a8c-43c4-4736-9d49-5cf132710952)

To this:

![Monosnap Home Page 2025-04-23 18-36-47](https://github.com/user-attachments/assets/69ec2fa4-0e6a-4174-996c-a932a07d3678)