### PR TITLE
INTERNAL-569 - Fix cached urls in cms content

### DIFF
--- a/app/code/Satoshi/SatoshiUi/Block/Widget/Category.php
+++ b/app/code/Satoshi/SatoshiUi/Block/Widget/Category.php
@@ -257,6 +257,7 @@ class Category extends ProductsList
             $this->getData('auto_resize_items'),
             $this->getData('max_products_count'),
             $this->currencyViewModel->getCurrentCurrencyCode(),
+            $this->getRequest()->getFullActionName(),
         ];
     }
 }

--- a/readymage.yaml
+++ b/readymage.yaml
@@ -6,7 +6,7 @@ playbooks:
     - npm:
         command: run build
 environments:
-  - name: readymage-satoshi-bmk-1720548019-var-umj
+  - name: readymage-satoshi-bmk-1720548019-dev-ddo
     build:
       themes:
         Magento/backend:

--- a/readymage.yaml
+++ b/readymage.yaml
@@ -20,3 +20,17 @@ environments:
           directory: app/design/frontend/Satoshi/Hyva/web/satoshi
           playbook: hyva
           languages: ["en_US"]
+  - name: readymage-satoshi-bmk-1720548019-var-umj
+    build:
+      themes:
+        Magento/backend:
+          area: adminhtml
+          languages: ["en_US"]
+        Magento/luma:
+          area: frontend
+          languages: ["en_US"]
+        Satoshi/Hyva:
+          area: frontend
+          directory: app/design/frontend/Satoshi/Hyva/web/satoshi
+          playbook: hyva
+          languages: ["en_US"]


### PR DESCRIPTION
Fixed cached URLs in cms content.

Steps to reproduce:
1. Flush the cache
2. Open the homepage from the admin dashboard CMS page
3. Then open the homepage in the storefront, the product URLs in the sliders are wrong

Ticket: https://scandiflow.atlassian.net/browse/INTERNAL-569